### PR TITLE
Add Mention of RBAC to Setup Error

### DIFF
--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -4,21 +4,35 @@ import {ReactNode} from "react";
 export default function Setup({children}: { children: ReactNode }) {
     if (!import.meta.env.VITE_STYTCH_PUBLIC_TOKEN) {
         return (
-            <>
-                <h1>
-                    Error: Stytch Not Configured Yet
-                </h1>
-                <p>
+            <div className="error-screen">
+                <h1>Error: Stytch Not Configured Yet</h1>
+                
+                <div className="error-content">
+                    <p className="error-intro">
                     Full setup instructions are available in the{' '}
-                    <a href="https://github.com/stytchauth/mcp-stytch-b2b-okr-manager">README</a>.
-                    Make sure you have configured the following:
-                    <ul>
-                        <li><code>VITE_STYTCH_PUBLIC_TOKEN</code> in your <code>.env.local</code></li>
-                        <li><code>STYTCH_PROJECT_ID</code> in your <code>.dev.vars</code></li>
-                        <li><code>STYTCH_PROJECT_SECRET</code> in your <code>.dev.vars</code></li>
-                    </ul>
-                </p>
-            </>
+                        <a href="https://github.com/stytchauth/mcp-stytch-b2b-okr-manager">README</a>.
+                    </p>
+
+                    <div className="error-section">
+                        <h2>Required Environment Variables</h2>
+                        <p>Make sure you have configured the following:</p>
+                        <ul className="env-vars">
+                            <li><code>VITE_STYTCH_PUBLIC_TOKEN</code> in your <code>.env.local</code></li>
+                            <li><code>STYTCH_PROJECT_ID</code> in your <code>.dev.vars</code></li>
+                            <li><code>STYTCH_PROJECT_SECRET</code> in your <code>.dev.vars</code></li>
+                        </ul>
+                    </div>
+                    <div className="error-section">
+                        <h2>Required RBAC Policy</h2>
+                        <p>
+                            Using your <a href="https://stytch.com/dashboard/settings/management-api">Management API Credentials</a> run the following script:
+                        </p>
+                        <div className="code-block">
+                            <code>npm update-policy.js --project-id $STYTCH_PROJECT_ID --key-id $MANAGEMENT_API_KEY_ID --secret $MANAGEMENT_API_SECRET</code>
+                        </div>
+                    </div>
+                </div>
+            </div>
         )
     }
 

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -25,7 +25,7 @@ export default function Setup({children}: { children: ReactNode }) {
                     <div className="error-section">
                         <h2>Required RBAC Policy</h2>
                         <p>
-                            Using your <a href="https://stytch.com/dashboard/settings/management-api">Management API Credentials</a> run the following script:
+                            If you have not done so already, create a <a href="https://stytch.com/dashboard/settings/management-api">Management API Key</a> and run the following:
                         </p>
                         <div className="code-block">
                             <code>npm update-policy.js --project-id $STYTCH_PROJECT_ID --key-id $MANAGEMENT_API_KEY_ID --secret $MANAGEMENT_API_SECRET</code>

--- a/src/index.css
+++ b/src/index.css
@@ -169,3 +169,86 @@ button.tiny {
 .complete {
     text-decoration: line-through;
 }
+
+/* Error Screen Styles */
+.error-screen {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 1.5rem;
+    background-color: rgb(251, 250, 249);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.error-screen h1 {
+    color: rgb(29, 29, 29);
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+    font-weight: 600;
+}
+
+.error-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.error-intro {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: rgb(29, 29, 29);
+}
+
+.error-section {
+    background-color: white;
+    padding: 1rem;
+    border-radius: 6px;
+    border-left: 3px solid #1D1D1D;
+}
+
+.error-section h2 {
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+    color: rgb(29, 29, 29);
+    font-weight: 600;
+}
+
+.error-section p {
+    margin-bottom: 0.75rem;
+    line-height: 1.5;
+    color: rgb(29, 29, 29);
+    font-size: 0.95rem;
+}
+
+.code-block {
+    background-color: #1D1D1D;
+    padding: 0.75rem;
+    border-radius: 4px;
+    margin: 0.75rem 0;
+}
+
+.code-block code {
+    color: white;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.85rem;
+}
+
+.env-vars {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.env-vars li {
+    background-color: white;
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.5rem;
+    border-radius: 4px;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.85rem;
+    border: 1px solid rgba(29, 29, 29, 0.1);
+}
+
+.env-vars li:last-child {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
# Description
While technically the setup error screen is shown when you don't have your Stytch credentials set, I'm a _little_ worried that people will click on the `Deploy to Cloudflare` button from their blog post and not actually review the README

To prevent this resulting in people hitting `invalid_scope` errors, adding a callout about the RBAC script to this page

<img width="841" alt="Screenshot 2025-04-04 at 2 25 12 PM" src="https://github.com/user-attachments/assets/892d3450-f9de-49f9-ad78-698a0f2b3076" />


